### PR TITLE
Fix chown and permission issues

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       upstream: development
       tags: |-
+        develop
         alpine-develop
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -5,32 +5,36 @@ for [stashapp/stash#4300](https://github.com/stashapp/stash/issues/4300)
   - PUID/ PGID switching support
 - TZ settings
 - CUDA/ QSV images
-  - NVENV encoding session patches
-- automatic dependency installs
+  - NVENC encoding session patches
+- automatic python dependency installs
 
-## latest/ alpine
-- built on alpine linux, no hardware acceleration support
-```
-docker pull ghcr.io/feederbox826/stash-s6:alpine
-```
+-----
+# Tags
 
-## hwaccel
-- built on debian, hardware acceration support via jellyfin-ffmpeg
-- utilizes [jellyfin-ffmpeg](https://jellyfin.org/docs/general/administration/hardware-acceleration/)
+## `latest` / `alpine`
 ```
-docker pull ghcr.io/feederbox826/stash-s6:hwaccel
+ghcr.io/feederbox826/stash-s6:alpine
 ```
+no hardware acceleration, built on alpine linux
+## `hwaccel`
+```
+ghcr.io/feederbox826/stash-s6:hwaccel
+```
+hardware acceleration from [jellyfin-ffmpeg](https://jellyfin.org/docs/general/administration/hardware-acceleration/), built on debian
 
-## Deprecation warning
-The following image aliases will be removed
-- hwaccel-jf
+## `-develop` variants
+Append `-develop` to the tag to run the development builds of stash
+- `develop` / `alpine-develop`
+- `hwaccel-develop`
 
-## Jellyfin-ffmpeg7 alpha
-- same as hwaccel, uses jellyfin-ffmpeg7
-- could possibly break and blow up, but just replace with `hwaccel-develop` to revert
-```
-docker pull ghcr.io/feederbox826/stash-s6:hwaccel-develop-jf7
-```
+## `hwaccel-develop-jf7` beta
+- uses jellyfin-ffmpeg7 (BETA), replace with `hwaccel-develop` to revert
+- please report any ffmpeg quirks and issues
+
+## deprecated tags
+- `hwaccel-jf` and `hwaccel-develop-jf`
+
+These tag will be removed with the release of v0.28, please switch to `hwaccel` and `hwaccel-develop` respectively
 
 ## environment variables
 `PUID` - Process User ID  
@@ -41,7 +45,7 @@ docker pull ghcr.io/feederbox826/stash-s6:hwaccel-develop-jf7
 
 ## migration-specific environment variables
 `MIGRATE` - automatic migration from `stashapp/stash` or `hotio/stash`  
-`SKIP_CHOWN` - skips chown operations for /config directory  
+`SKIP_CHOWN` - skips chown operations for `/config` directory  
 
 ## Run modes
 ### `stashapp/stash compatibility`

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ These tag will be removed with the release of v0.28, please switch to `hwaccel` 
 `CUSTOM_CERT_PATH` - Path to custom root certificates to be added to stash (defaults to `/config/certs`)  
 
 ## migration-specific environment variables
-`MIGRATE` - automatic migration from `stashapp/stash` or `hotio/stash`  
-`SKIP_CHOWN` - skips chown operations for `/config` directory  
+`MIGRATE` - automatic migration from `stashapp/stash` or `hotio/stash`
 
 ## Run modes
 ### `stashapp/stash compatibility`

--- a/TODO.md
+++ b/TODO.md
@@ -1,3 +1,2 @@
 - [ ] adapt matrix into builder
-- [ ] create job dependencies between croxx-platform build and matrix build
 - [ ] add makefile for matrix builder

--- a/dockerfile/alpine.Dockerfile
+++ b/dockerfile/alpine.Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG \
   STASH_TAG="latest" \
-  UPSTREAM_STASH="stashapp/stash:${STASH_TAG}" \
-  UV_VERSION="0.4.6"
+  UPSTREAM_STASH="stashapp/stash:${STASH_TAG}"
 FROM $UPSTREAM_STASH AS stash
 
 FROM alpine:3.20 AS final

--- a/dockerfile/alpine.Dockerfile
+++ b/dockerfile/alpine.Dockerfile
@@ -51,10 +51,7 @@ RUN \
     ca-certificates \
     curl \
     ffmpeg \
-    gcc \
     python3 \
-    python3-dev \
-    musl-dev \
     nano \
     ncdu \
     ruby \

--- a/dockerfile/alpine.Dockerfile
+++ b/dockerfile/alpine.Dockerfile
@@ -71,7 +71,7 @@ RUN \
     faraday
 RUN \
   echo "**** create stash user and make our folders ****" && \
-  useradd -u 1000 -U -d /config -s /bin/false stash && \
+  useradd -u 911 -U -d /config -s /bin/false stash && \
   usermod -G users stash && \
   mkdir -p \
     /config \

--- a/dockerfile/hwaccel.Dockerfile
+++ b/dockerfile/hwaccel.Dockerfile
@@ -80,10 +80,8 @@ RUN \
     apt-get install -y \
       --no-install-recommends \
       --no-install-suggests \
-      gcc \
       gosu \
       jellyfin-ffmpeg${FFMPEG_VERSION} \
-      libc-dev \
       libvips-tools \
       locales \
       nano \

--- a/dockerfile/hwaccel.Dockerfile
+++ b/dockerfile/hwaccel.Dockerfile
@@ -123,7 +123,7 @@ RUN \
       faraday
 RUN \
   echo "**** create stash user and make our folders ****" && \
-  useradd -u 1000 -U -d /config -s /bin/bash stash && \
+  useradd -u 911 -U -d /config -s /bin/bash stash && \
   usermod -G users stash && \
   usermod -G video stash && \
   mkdir -p \

--- a/dockerfile/hwaccel.Dockerfile
+++ b/dockerfile/hwaccel.Dockerfile
@@ -1,8 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG \
   STASH_TAG="latest" \
-  UPSTREAM_STASH="stashapp/stash:${STASH_TAG}" \
-  UV_VERSION="0.4.6"
+  UPSTREAM_STASH="stashapp/stash:${STASH_TAG}"
 FROM $UPSTREAM_STASH AS stash
 
 FROM python:3.12-slim-bookworm AS final

--- a/docs/switch-to-hwaccel.md
+++ b/docs/switch-to-hwaccel.md
@@ -8,6 +8,7 @@ services:
 -   image: stashapp/stash
 +   image: nerethos/stash-jellyfin-ffmpeg
 
+-   image: stashapp/stash
 +   image: ghcr.io/feederbox826/stash-s6:hwaccel
 ...
 ```

--- a/stash/root/defaults/intel-drivers.sh
+++ b/stash/root/defaults/intel-drivers.sh
@@ -6,7 +6,7 @@
 # Description: Install Intel compute-runtime and non-free drivers
 
 install_nonfree_drivers() {
-  if [ ! "$(TARGETPLATFORM)" == 'linux/amd64' ]; then
+  if [ "$(uname -m)" != "x86_64" ]; then
     return 0
   fi
   apt install -y \

--- a/stash/root/defaults/requirements.txt
+++ b/stash/root/defaults/requirements.txt
@@ -1,6 +1,6 @@
-bencoder.pyx
 bs4
 cloudscraper
+fastbencode
 lxml
 mechanicalsoup
 pystashlib

--- a/stash/root/opt/branding
+++ b/stash/root/opt/branding
@@ -14,4 +14,4 @@
          XXXXXXXXX   XXXXXXXXX         
             XXXXXX   XXXXXX            
                                        
-             stashapp/stash            
+    feederbox826/stash-s6  ⚡+🐍+🎭    

--- a/stash/root/opt/entrypoint.sh
+++ b/stash/root/opt/entrypoint.sh
@@ -44,8 +44,12 @@ reown_r() {
   chown -R "$CURUSR" "$1" && \
     chmod -R "u=rwx" "$1"
 }
-# check directory permissions
+# check that directory is writeable
 check_dir_perms() {
+  runas test "-w $1" && return 0 || return 1
+}
+# check file is writeable and executable
+check_file_perms() {
   (runas test "-w $1" && runas stat "$1" >/dev/null 2>&1) \
     && return 0 || return 1
 }
@@ -362,7 +366,7 @@ if [ -e "$STASHAPP_STASH_ROOT" ] && [ "$MIGRATE" != "TRUE" ] && [ "$MIGRATE" != 
   CURUSR="$PUID"
   CURGRP="$PGID"
   # check if directories and config file is writeable
-  if ! check_dir_perms $STASHAPP_STASH_CONFIG; then
+  if ! check_file_perms $STASHAPP_STASH_CONFIG; then
     # revert changes, warn later
     CURUSR="$(id -u)"
     CURGRP="$(id -g)"

--- a/stash/root/opt/entrypoint.sh
+++ b/stash/root/opt/entrypoint.sh
@@ -58,12 +58,11 @@ reown() {
 }
 # check that directory is writeable
 check_dir_perms() {
-  runas test "-w $1" && return 0 || return 1
+  runas test "-w $1"
 }
 # check file is writeable and executable
 check_file_perms() {
-  (runas test "-w $1" && runas stat "$1" >/dev/null 2>&1) \
-    && return 0 || return 1
+  runas test "-w $1" && runas stat "$1" >/dev/null 2>&1
 }
 # try to access dir as user and reown if necessary
 try_reown_r() {
@@ -145,7 +144,7 @@ check_migrate() {
 # detect if migration is needed and migrate
 try_migrate() {
   # run if MIGRATE is set
-  if [ "$MIGRATE" == "TRUE" ] || [ "$MIGRATE" == "true" ]; then
+  if [[ "$MIGRATE" == "TRUE" || "$MIGRATE" == "true" ]]; then
     if [ -e "/config/.stash" ]; then
       hotio_stash_migration
     elif [ -e "$STASHAPP_STASH_ROOT" ] && [ -f "$STASHAPP_STASH_CONFIG" ]; then
@@ -383,13 +382,13 @@ user_status() {
 trap finish EXIT
 # user setup
 # check if running in stashapp/stash compatibility mode
-if [ -e "$STASHAPP_STASH_ROOT" ] && [ "$MIGRATE" != "TRUE" ] && [ "$MIGRATE" != "true" ]; then
+if [ -e "$STASHAPP_STASH_ROOT" ] && [[ "$MIGRATE" != "TRUE" ]] && [[ "$MIGRATE" != "true" ]]; then
   COMPAT_MODE=1
   # change UID/GID for test
   CURUSR="$PUID"
   CURGRP="$PGID"
   # check if directories and config file is writeable
-  if ! check_file_perms $STASHAPP_STASH_CONFIG; then
+  if ! check_file_perms "$STASHAPP_STASH_CONFIG"; then
     # revert changes, warn later
     CURUSR="$(id -u)"
     CURGRP="$(id -g)"

--- a/stash/root/opt/entrypoint.sh
+++ b/stash/root/opt/entrypoint.sh
@@ -204,7 +204,7 @@ stashapp_stash_migration() {
   check_migrate "blobs_path" \
     "$CONFIG_ROOT/blobs" "$STASHAPP_STASH_ROOT" \
     "$STASH_BLOBS"
-  check_migrate  "plugins_path" \
+  check_migrate "plugins_path" \
     "$CONFIG_ROOT/plugins" "$STASHAPP_STASH_ROOT"
   check_migrate "scrapers_path" \
     "$CONFIG_ROOT/scrapers" "$STASHAPP_STASH_ROOT"

--- a/stash/root/opt/entrypoint.sh
+++ b/stash/root/opt/entrypoint.sh
@@ -274,7 +274,7 @@ check_ffmpeg() {
     err "💥 ffmpeg/ffprobe is present at $1, this will likely cause issues. Please remove it"
   fi
 }
-# patch multistream NVNEC from keylase/nvidia-patch
+# patch multistream NVENC from keylase/nvidia-patch
 patch_nvidia() {
   if [ -n "${SKIP_NVIDIA_PATCH}" ]; then
     debug "⏩🖥️ Skipping nvidia patch because of SKIP_NVIDIA_PATCH"

--- a/stash/root/opt/entrypoint.sh
+++ b/stash/root/opt/entrypoint.sh
@@ -11,9 +11,10 @@ PUID=${PUID:-911}
 PGID=${PGID:-911}
 # environment variables
 CONFIG_ROOT="/config"
-PYTHON_REQS="${CONFIG_ROOT}/requirements.txt"
+PYTHON_REQS="$CONFIG_ROOT/requirements.txt"
 STASHAPP_STASH_ROOT="/root/.stash"
 COMPAT_MODE=0
+ROOTLESS=0
 # shellcheck disable=SC1091
 source "/opt/shell-logger.sh"
 export LOGGER_COLOR="always"
@@ -23,50 +24,36 @@ export LOGGER_SHOW_FILE="0"
 #{{{🔑 permission functions
 # run as CURUSR if possible
 runas() {
-  if [[ ${ROOTLESS} -eq 1 ]]; then
+  if [[ $ROOTLESS -eq 1 ]] || [[ $(id -u) -eq 1 ]]; then
     "$@"
   else
-    su-exec "${CURUSR}:${CURGRP}" "$@"
+    su-exec "$CURUSR:$CURGRP" "$@"
   fi
 }
 # recursive chown as CURUSR:CURGRP
 reown_r() {
-  # if forced, chown is necessary for function, so SKIP_CHOWN is ignored
-  local force=$1
-  if [ ${ROOTLESS} -eq 1 ]; then
-    return
-  # if not forced and SKIP_CHOWN, return
-  elif [[ ! $force ]] && [[ $SKIP_CHOWN ]]; then
-    return
+  # if ROOTLESS, cannot chown so exit early
+  if [[ $ROOTLESS -eq 1 ]]; then
+    return 1
   fi
-  info "🔑 owning $1"
+  info "🔑 chowning $1"
   # if DNE, assume and create directory
   [ ! -e "$1" ] && mkdir -p "$1"
-  chown -R "${CURUSR}:${CURGRP}" "$1" && \
-    chmod -R "=rwx" "$1"
+  # change owner and permissions for owner
+  chown -R "$CURUSR" "$1" && \
+    chmod -R "u=rwx" "$1"
 }
 # check directory permissions
 check_dir_perms() {
-  [ -w "${1}" ] && return 0 || return 1
+  runas test -w "$1" && return 0 || return 1
 }
-# warn about directory permissions
-warn_dir_perms() {
-  local chkdir="${1}"
-  local msg="⚠️ ${chkdir} is not writeable by stash"
-  if [ -n "${SKIP_CHOWN}" ]; then
-    msg="${msg} and SKIP_CHOWN is set"
-  fi
-  warn "${msg}"
-  warn "💻 Please run 'chown -R ${CURUSR}:${CURGRP} ${chkdir}' on the host to fix this"
-  exit 1
-}
-# try to access and reown if necessary
+# try to access as user and reown if necessary
 try_reown() {
   local chkdir="$1"
-  local force="$2"
   # if permission issues and reown fails, warn
-  if ! check_dir_perms "${chkdir}" && ! reown_r "${chkdir}" "${force}"; then
-    warn_dir_perms "${chkdir}"
+  if ! check_dir_perms "$chkdir" && ! reown_r "$chkdir"; then
+    warn "⚠️ $chkdir is not writeable by stash"
+    warn "💻 Please run 'chown -R $CURUSR:$CURGRP $chkdir' on the host to fix this"
   fi
 }
 #}}} /🔑
@@ -74,76 +61,90 @@ try_reown() {
 #{{{🚛 migration helpers
 # check if path in key can be migrated
 get_config_key() {
-  local key="${1}"
-  local default="${2}"
-  value=$(yq -r ".${key}" "${STASH_CONFIG_FILE}")
-  if [ "${value}" = "null" ]; then
-    value="${default}"
+  local key="$1"
+  local default="$2"
+  value=$(yq -r ".$key" "$STASH_CONFIG_FILE")
+  if [ "$value" = "null" ]; then
+    value="$default"
   fi
-  echo "${value}"
+  echo "$value"
 }
 # move and update key to new path
 migrate_update() {
-  info "🚚 migrating ${1} to ${3}"
-  local key="${1}"
-  local old_path="${2}"
-  local new_path="${3}"
-  # old path doesn't exist, create instead
-  if [ -e "${old_path}" ]; then
-    mv -n "${old_path}" "${new_path}" && \
-      reown_r "${new_path}" "FORCE"
-  else
-    reown_r "${new_path}" "FORCE"
-  fi
-  yq -i ".${key} = \"${new_path}\"" "${CONFIG_YAML}"
+  local key="$1"
+  local old_path="$2"
+  local new_path="$3"
+  info "🚚 migrating $key to $new_path"
+  # move & reown if old path exists
+  [ -e "$old_path" ] && mv -n "$old_path" "$new_path"
+  # if doesn't exist, just create and reown
+  reown_r "$new_path"
+  yq -i ".$key = \"$new_path\"" "$CONFIG_YAML"
 }
+# check config value and migrate if possible
 check_migrate() {
-  local key="${1}" # key in yaml config
-  local config_path="${2}" # new /config path
-  local old_root="${3}" # old "config" storage directory
-  local env_path="${4}" # environment variable to override path of
+  local key="$1" # key in yaml config
+  local config_path="$2" # new /config path
+  local old_root="$3" # old "config" storage directory
+  local env_path="$4" # environment variable to override path of
   # get value of key
   local old_path
-  old_path=$(yq ."${key}" "${CONFIG_YAML}")
+  old_path=$(yq ."$key" "$CONFIG_YAML")
   # remove quotes
   old_path="${old_path%\"}"
   old_path="${old_path#\"}"
   # SKIP if not set
-  if [ "${old_path}" = "null" ]; then
-    info "⏩🚛 skip migrating ${key}" as it is not set
+  if [ "$old_path" = "null" ]; then
+    info "⏩🚛 skip migrating $key" as it is not set
   # SKIP if not in old_root
-  elif ! [[ "${old_path}" == *"${old_root}"* ]]; then
-    info "⏩🚛 not migrating ${key} as it is not in ${old_root}"
+  elif ! [[ "$old_path" == *"$old_root"* ]]; then
+    info "⏩🚛 not migrating $key as it is not in $old_root"
   # SKIP if path is a mount
-  elif mountpoint -q "${old_path}"; then
-    warn "⏩🚛 skip migrating ${key} as it is a mount"
+  elif mountpoint -q "$old_path"; then
+    warn "⏩🚛 skip migrating $key as it is a mount"
   # MOVE to path defined in environment variable if mounted
-  elif [ -n "${env_path}" ] && [ -e "${env_path}" ] && mountpoint -q "${env_path}"; then
-    migrate_update "${key}" "${old_path}" "${env_path}"
+  elif [ -n "$env_path" ] && [ -e "$env_path" ] && mountpoint -q "$env_path"; then
+    migrate_update "$key" "$old_path" "$env_path"
   # MOVE to /config if /config is mounted
   elif [ -e "/config" ] && mountpoint -q "/config"; then
-    migrate_update "${key}" "${old_path}" "${config_path}"
+    migrate_update "$key" "$old_path" "$config_path"
   # /config not mounted, error
   else
-    info "🛑🚛 not migrating ${key} as /config is not mounted"
+    info "🛑🚛 not migrating $key as /config is not mounted"
   fi
 }
 # detect if migration is needed and migrate
 try_migrate() {
   # run if MIGRATE is set
-  if [ "${MIGRATE}" == "TRUE" ] || [ "${MIGRATE}" == "true" ]; then
+  if [ "$MIGRATE" == "TRUE" ] || [ "$MIGRATE" == "true" ]; then
     if [ -e "/config/.stash" ]; then
       hotio_stash_migration
-    elif [ -e "${STASHAPP_STASH_ROOT}" ] && [ -f "${STASHAPP_STASH_ROOT}/config.yml" ]; then
+    elif [ -e "$STASHAPP_STASH_ROOT" ] && [ -f "$STASHAPP_STASH_ROOT/config.yml" ]; then
       stashapp_stash_migration
     else
       warn "⏩🚚 MIGRATE is set, but no migration is needed"
     fi
   # MIGRATE not set but might be needed
-  elif [ -e "${STASHAPP_STASH_ROOT}" ]; then
-    warn "⚙️ ${STASHAPP_STASH_ROOT} exists, but MIGRATE is not set. Running in stashapp/stash compatibility mode"
-    export STASH_CONFIG_FILE="${STASHAPP_STASH_ROOT}/config.yml"
+  elif [ -e "$STASHAPP_STASH_ROOT" ]; then
+    warn "⚙️ $STASHAPP_STASH_ROOT exists, but MIGRATE is not set. Running in stashapp/stash compatibility mode"
+    export STASH_CONFIG_FILE="$STASHAPP_STASH_ROOT/config.yml"
   fi
+}
+# check if permissions for common directories are correct
+check_common_perms() {
+  info "🚛 checking common directory permissions"
+  # check if critical config paths are writeable
+  try_reown "$CONFIG_ROOT" || return 1
+  if [ -f "$STASH_CONFIG_FILE" ]; then
+    try_reown "$STASH_CONFIG_FILE" || return 1
+  fi
+  # check if envvars are writeable
+  local envvars=("$STASH_BLOBS" "$STASH_CACHE" "$STASH_GENERATED")
+  for envvar in "${envvars[@]}"; do
+    if [[ $envvar ]] && [ -d "$envvar" ]; then
+      try_reown "$envvar" || return 1
+    fi
+  done
 }
 #}}} /🚛
 
@@ -159,42 +160,41 @@ hotio_stash_migration() {
 # migrate from stashapp/stash
 stashapp_stash_migration() {
   # check if /config is mounted
-  if ! mountpoint -q "${CONFIG_ROOT}"; then
-    warn "🛑🚚 aborting migration from stashapp/stash as ${CONFIG_ROOT} is not mounted"
+  if ! mountpoint -q "$CONFIG_ROOT"; then
+    warn "🛑🚚 aborting migration from stashapp/stash as $CONFIG_ROOT is not mounted"
     return 1
-  else
-    try_reown "${CONFIG_ROOT}" "FORCE"
   fi
+  try_reown "$CONFIG_ROOT"
   info "🚚 migrating from stashapp/stash"
   local old_root="/root/.stash"
   # set config yaml path for re-use
-  CONFIG_YAML="${old_root}/config.yml"
+  CONFIG_YAML="$old_root/config.yml"
   # migrate and check all paths in yml
-  check_migrate "generated"     "${CONFIG_ROOT}/generated"        "${old_root}"  "${STASH_GENERATED}"
-  check_migrate "cache"         "${CONFIG_ROOT}/cache"            "${old_root}"  "${STASH_CACHE}"
-  check_migrate "blobs_path"    "${CONFIG_ROOT}/blobs"            "${old_root}"  "${STASH_BLOBS}"
-  check_migrate "plugins_path"  "${CONFIG_ROOT}/plugins"          "${old_root}"
-  check_migrate "scrapers_path" "${CONFIG_ROOT}/scrapers"         "${old_root}"
-  check_migrate "database"      "${CONFIG_ROOT}/stash-go.sqlite"  "${old_root}"
+  check_migrate "generated"     "$CONFIG_ROOT/generated"        "$old_root"  "$STASH_GENERATED"
+  check_migrate "cache"         "$CONFIG_ROOT/cache"            "$old_root"  "$STASH_CACHE"
+  check_migrate "blobs_path"    "$CONFIG_ROOT/blobs"            "$old_root"  "$STASH_BLOBS"
+  check_migrate "plugins_path"  "$CONFIG_ROOT/plugins"          "$old_root"
+  check_migrate "scrapers_path" "$CONFIG_ROOT/scrapers"         "$old_root"
+  check_migrate "database"      "$CONFIG_ROOT/stash-go.sqlite"  "$old_root"
   # forcefully move config.yml
-  mv -n "${old_root}/config.yml" "${STASH_CONFIG_FILE}"
+  mv -n "$old_root/config.yml" "$STASH_CONFIG_FILE"
   # forcefully move database backups
-  mv -n "${old_root}/stash-go.sqlite*" "${CONFIG_ROOT}"
+  mv -n "$old_root/stash-go.sqlite*" "$CONFIG_ROOT"
   # forcefully move misc files
   mv -n \
-    "${old_root}/custom.css" \
-    "${old_root}/custom.js" \
-    "${old_root}/custom-locales.json" \
-    "${CONFIG_ROOT}"
+    "$old_root/custom.css" \
+    "$old_root/custom.js" \
+    "$old_root/custom-locales.json" \
+    "$CONFIG_ROOT"
   # migrate all other misc files
   info "🚚‼️ leftover files:"
-  ls -la "${old_root}"
+  ls -la "$old_root"
   # reown files
-  reown_r "${CONFIG_ROOT}" "FORCE"
+  reown_r "$CONFIG_ROOT"
   # symlink old directory for compatibility
-  info "🚛 symlinking ${old_root} to ${CONFIG_ROOT}"
-  rmdir "${old_root}" && \
-    ln -s "${CONFIG_ROOT}" "${old_root}"
+  info "🚛 symlinking $old_root to $CONFIG_ROOT"
+  rmdir "$old_root" && \
+    ln -s "$CONFIG_ROOT" "$old_root"
 }
 #}}} /🚚
 
@@ -202,11 +202,11 @@ stashapp_stash_migration() {
 # search directory for requirements.txt
 search_dir_reqs() {
   local target_dir="$1"
-  if [ ! -d "${target_dir}" ]; then
-    warn "🐍 ${target_dir} not found, skipping requirement search"
+  if [ ! -d "$target_dir" ]; then
+    warn "🐍 $target_dir not found, skipping requirement search"
     return 0
   fi
-  find "${target_dir}" -type f -name "requirements.txt" -print0 | while IFS= read -r -d '' file
+  find "$target_dir" -type f -name "requirements.txt" -print0 | while IFS= read -r -d '' file
   do
     parse_reqs "$file"
   done
@@ -214,59 +214,57 @@ search_dir_reqs() {
 # parse requirements
 parse_reqs() {
   local file="$1"
-  info "🐍 Parsing ${file}"
-  echo "# ${file}" >> "${PYTHON_REQS}"
+  info "🐍 Parsing $file"
+  echo "# $file" >> "$PYTHON_REQS"
   while IFS="" read -r p || [ -n "$p" ]
   do
-    [[ "${p}" = \#* ]] && continue # skip comments
+    [[ "$p" = \#* ]] && continue # skip comments
     read -r -a pkgarg <<< "$p"
     debug "🐍 Adding ${pkgarg[0]} to requirements.txt"
-    echo "${pkgarg[0]}" >> "${PYTHON_REQS}"
+    echo "${pkgarg[0]}" >> "$PYTHON_REQS"
   done < "$file"
 }
 find_reqs() {
   # check that config.yml exists
-  if [ ! -f "${STASH_CONFIG_FILE}" ]; then
+  if [ ! -f "$STASH_CONFIG_FILE" ]; then
     warn "🐍 config.yml not found, skipping requirements.txt generation"
     return 0
   fi
-  # iterate over plugins
-  search_dir_reqs "$(get_config_key "plugins_path"  "${CONFIG_ROOT}/plugins")"
-  # iterate over scrapers
-  search_dir_reqs "$(get_config_key "scrapers_path" "${CONFIG_ROOT}/scrapers")"
+  # iterate over plugins and scrapers
+  search_dir_reqs "$(get_config_key "plugins_path"  "$CONFIG_ROOT/plugins")"
+  search_dir_reqs "$(get_config_key "scrapers_path" "$CONFIG_ROOT/scrapers")"
 }
 # dedupe requirements.txt
 dedupe_reqs() {
-  awk '!seen[$0]++' "${PYTHON_REQS}" > "${PYTHON_REQS}.tmp"
-  mv "${PYTHON_REQS}.tmp" "${PYTHON_REQS}"
+  awk '!seen[$0]++' "$PYTHON_REQS" > "$PYTHON_REQS.tmp"
+  mv "$PYTHON_REQS.tmp" "$PYTHON_REQS"
 }
 # install python dependencies
 install_python_deps() {
   # copy over /defaults/requirements if it doesn't exist
-  if [ ! -f "${PYTHON_REQS}" ] || [ ! -s "${PYTHON_REQS}" ]; then
+  if [ ! -f "$PYTHON_REQS" ] || [ ! -s "$PYTHON_REQS" ]; then
     debug "🐍 Copying default requirements.txt"
-    cp "/defaults/requirements.txt" "${PYTHON_REQS}" && \
-      reown_r "${PYTHON_REQS}" "FORCE"
+    cp "/defaults/requirements.txt" "$PYTHON_REQS" && \
+      try_reown "$PYTHON_REQS"
   fi
   find_reqs
   dedupe_reqs
   # fix /pip-install directory
   info "🐍 Installing/upgrading python requirements..."
   # UV_CACHE_DIR = /pip-install/cache
-  reown_r "${UV_TARGET}" "FORCE" && \
-    reown_r "${UV_CACHE_DIR}" "FORCE" && \
+  try_reown "$UV_TARGET" && \
+    try_reown "$UV_CACHE_DIR" && \
     runas uv pip install \
       --system \
-      --target "${UV_TARGET}" \
-      --requirement "${PYTHON_REQS}"
+      --target "$UV_TARGET" \
+      --requirement "$PYTHON_REQS"
 }
 #}}} /🐍
 
 #{{{ misc helpers
 # trap exit and error
 finish() {
-  result=$?
-  exit ${result}
+  exit $?
 }
 # check if local ffmpeg is present
 check_ffmpeg() {
@@ -276,7 +274,7 @@ check_ffmpeg() {
 }
 # patch multistream NVENC from keylase/nvidia-patch
 patch_nvidia() {
-  if [ -n "${SKIP_NVIDIA_PATCH}" ]; then
+  if [[ $SKIP_NVIDIA_PATCH ]]; then
     debug "⏩🖥️ Skipping nvidia patch because of SKIP_NVIDIA_PATCH"
     return 0
   elif [ $ROOTLESS -eq 1 ]; then
@@ -291,8 +289,8 @@ patch_nvidia() {
     "https://raw.githubusercontent.com/keylase/nvidia-patch/master/patch.sh"
   chmod "+x" "/usr/local/bin/nv-patch.sh"
   local PATCH_OUTPUT_DIR="/patched-lib"
-  mkdir -p "${PATCH_OUTPUT_DIR}"
-  echo "${PATCH_OUTPUT_DIR}" > "/etc/ld.so.conf.d/000-patched-lib.conf"
+  mkdir -p "$PATCH_OUTPUT_DIR"
+  echo "$PATCH_OUTPUT_DIR" > "/etc/ld.so.conf.d/000-patched-lib.conf"
   PATCH_OUTPUT_DIR=/patched-lib /usr/local/bin/nv-patch.sh -s
   cd /patched-lib && \
   for f in * ; do
@@ -306,9 +304,9 @@ patch_nvidia() {
 # install custom certificates
 install_custom_certs() {
   CERT_PATH="${CUSTOM_CERT_PATH:-/config/certs}"
-  if [ -d "${CERT_PATH}" ]; then
-    info "🛡️ Installing custom certificates from ${CERT_PATH}"
-    cp -r "${CERT_PATH}"/* /usr/local/share/ca-certificates/
+  if [ -d "$CERT_PATH" ]; then
+    info "🛡️ Installing custom certificates from $CERT_PATH"
+    cp -r "$CERT_PATH"/* /usr/local/share/ca-certificates/
     update-ca-certificates
   fi
 }
@@ -318,54 +316,60 @@ install_custom_certs() {
 trap finish EXIT
 # user setup
 # check if running in stashapp/stash compatibility mode
-if [ -e "${STASHAPP_STASH_ROOT}" ] && [ "${MIGRATE}" != "TRUE" ] && [ "${MIGRATE}" != "true" ]; then
+if [ -e "$STASHAPP_STASH_ROOT" ] && [ "$MIGRATE" != "TRUE" ] && [ "$MIGRATE" != "true" ]; then
   COMPAT_MODE=1
   ROOTLESS=0
   # check if /root is writeable, if not warn
   # change UID/GID for test
   groupmod -o -g "$PGID" stash
   usermod  -o -u "$PUID" stash
-  if ! runas check_dir_perms "${STASHAPP_STASH_ROOT}"; then
-    warn "🛑🔑 Could not change to PUID/PGID due to ${STASHAPP_STASH_ROOT} not being writeable"
+  if ! check_dir_perms "$STASHAPP_STASH_ROOT"; then
+    warn "🛑🔑 Could not change to PUID/PGID due to $STASHAPP_STASH_ROOT not being writeable"
     CURUSR="$(id -u)"
     CURGRP="$(id -g)"
   else
-    info "🎭 Changing to PUID/PGID since ${STASHAPP_STASH_ROOT} is writeable"
-    CURUSR="${PUID}"
-    CURGRP="${PGID}"
+    info "🎭 Changing to PUID/PGID since $STASHAPP_STASH_ROOT is writeable"
+    CURUSR="$PUID"
+    CURGRP="$PGID"
   fi
-  info "⚙️ Running in stashapp/stash full compatibility mode. CHOWN, migration and PUID/PGID skipped."
+  info "⚙️ Running in stashapp/stash full compatibility mode. migration and PUID/PGID skipped."
 # check if running with or without root
 elif [ "$(id -u)" -ne 0 ]; then
   ROOTLESS=1
   CURUSR="$(id -u)"
   CURGRP="$(id -g)"
-  info "⏩ Not running as root. CHOWN, migration and PUID/PGID skipped."
-else # if root, use PUID/PGID
-  ROOTLESS=0
-  CURUSR="${PUID}"
-  CURGRP="${PGID}"
-  # change UID/GID accordingly
+  info "⏩ Not running as root. migration and PUID/PGID skipped."
+# if root, use PUID/PGID
+else
   groupmod -o -g "$PGID" stash
   usermod  -o -u "$PUID" stash
+  if ! check_common_perms; then
+    CURUSR="$(id -u)"
+    CURGRP="$(id -g)"
+    warn "🛑🎭 Could not change to PUID/PGID due to permissions issues"
+  else
+    CURUSR="$PUID"
+    CURGRP="$PGID"
+    info "🎭 Changing to PUID/PGID since permissions check passed"
+  fi
 fi
 # print branding and donation info
 cat /opt/branding
 cat /opt/donate
 # print UID/GID
-echo '
+echo "
 ───────────────────────────────────────
 GID/UID
-───────────────────────────────────────'
-echo "
-User UID:    ${CURUSR}
-User GID:    ${CURGRP}
-HW Accel:    ${HWACCEL}
-$(if [ $ROOTLESS -eq 1 ]; then
+───────────────────────────────────────
+User UID:    $CURUSR
+User GID:    $CURGRP
+HW Accel:    $HWACCEL
+"
+if [ $ROOTLESS -eq 1 ]; then
   echo "Rootless:    TRUE"
 elif [ $COMPAT_MODE -eq 1 ]; then
   echo "stashapp/stash mode: TRUE"
-fi)"
+fi
 echo '
 ───────────────────────────────────────
 entrypoint.sh
@@ -377,14 +381,12 @@ patch_nvidia
 install_custom_certs
 # only chown if not in stashapp/stash compatibility mode
 if [ $COMPAT_MODE -ne 1 ]; then
-  info "🔑 Creating ${CONFIG_ROOT}"
-  try_reown "${CONFIG_ROOT}"
   # move to CONFIG_ROOT
-  cd "${CONFIG_ROOT}" || exit 1
+  cd "$CONFIG_ROOT" || exit 1
 fi
 # danger if ffmpeg present locally
-check_ffmpeg "${CONFIG_ROOT}"
-check_ffmpeg "${STASHAPP_STASH_ROOT}"
+check_ffmpeg "$CONFIG_ROOT"
+check_ffmpeg "$STASHAPP_STASH_ROOT"
 # finally start stash
 echo '
 Starting stash...


### PR DESCRIPTION
## size comparison
alpine: 791.47 -> 434.53 (-356.94MB)
hwaccel: 1380 -> 1120 (-260MB)

# entrypoint.sh
🔑 chown and permissions management
- remove `SKIP_CHOWN`
- only set u=rwx and owner when chown-ing
- split into reown/reown_r for non-recursive chown

🧩 stashapp/stash compatibility mode
- add consistent STASHAPP_STASH_CONFIG
- more robust checks for permissions
- don't fake ROOTLESS

🚚/🚛 Migration
- move config backups as well

🐍 Python
- be picky when finding python reqs
- drop [bencoder.pyx](https://github.com/stashapp/CommunityScrapers/pull/2077) for fastbencode
- drop build dependencies for python

📋 Startup checks
- add check for common directories
- be more verbose with error logs

🎭 user changing
- default to 911:911 in docker image as well
- log explanation if root is preserved

other
- remove unnecessary curly brackets

# Documentation
- add develop tag
- fix typo for NVENV -> NVENC
- reformat readme
- update branding

# 🐳 docker misc changes
- remove unused `UV_VERSION`
- fix arm64 installing intel drivers