### PR TITLE
Fix errors in add-py-build.sh

### DIFF
--- a/stash/root/opt/add-py-build.sh
+++ b/stash/root/opt/add-py-build.sh
@@ -17,15 +17,21 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
-# add build-base
+# install dependencies in a virtual package to make removal easier
+# virtual package contains:
+#  - build-case: gcc, make, development tools
+#  - git: for pip installs from git repos
+#  - python3-dev: python headers
+#  - musl-dev: c headers
+#  - linux-headers: kernel headers
 echo "Installing virtual package 'stash-py-build'"
 apk add \
   --no-cache \
-  --virtual stash-py-build \ # virtual package to make removal easier
-  build-base \ # gcc, make, development tools
-  git \ # git for pip installs from git repos
-  python3-dev \ # python headers
-  musl-dev \ # c headers
-  linux-headers # kernel headers
+  --virtual stash-py-build \
+  build-base \
+  git \
+  python3-dev \
+  musl-dev \
+  linux-headers
 
 echo "To remove build tools, run: apk del stash-py-build"


### PR DESCRIPTION
Comments cannot be used on lines continued with backslashes.

Without this fix, using the `INSTALL_PY_DEPS` option results in the following errors:

```
Installing virtual package 'stash-py-build'
fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz
ERROR: ' #' is not a valid child dependency, format is name([<>~=]version)
/opt/add-py-build.sh: line 25: build-base: not found
/opt/add-py-build.sh: line 26: git: not found
/opt/add-py-build.sh: line 27: python3-dev: not found
/opt/add-py-build.sh: line 28: musl-dev: not found
/opt/add-py-build.sh: line 29: linux-headers: not found
To remove build tools, run: apk del stash-py-build
```