### PR TITLE
fix: entrypoint privilege dropping and NFSv4 compatibility

### DIFF
--- a/stash/root/opt/entrypoint.sh
+++ b/stash/root/opt/entrypoint.sh
@@ -21,11 +21,14 @@ source "/opt/log.sh"
 
 # 🎭 run as CURUSR if possible
 runas() {
-   if [[ $ROOTLESS -eq 1 ]] || [[ $(id -u) -eq 0 ]]; then
+  if [[ $ROOTLESS -eq 1 ]]; then
     "$@"
   else
+    # Build supplementary groups: always include CURGRP, plus AVGID if set
+    local SUPPGRPS="$CURGRP"
+    [[ -n "$AVGID" ]] && SUPPGRPS="$SUPPGRPS,$AVGID"
     # shellcheck disable=SC2068
-    dropprs "$CURUSR:$CURGRP:$AVGID" $@
+    dropprs "$CURUSR:$CURGRP:$SUPPGRPS" $@
   fi
 }
 
@@ -40,8 +43,9 @@ reown_r() {
   # if DNE, assume and create directory
   [ ! -e "$1" ] && mkdir -p "$1"
   # change owner and permissions for owner
-  chown -R "$CURUSR" "$1" && \
-    chmod -R "u=rwx" "$1"
+  # chmod may fail on NFSv4 (aclmode=restricted) — non-fatal since chown ensures access
+  chown -R "$CURUSR" "$1"
+  chmod -R "u=rwx" "$1" 2>/dev/null || true
 }
 # non-recursive chown as CURUSR
 reown() {
@@ -51,8 +55,9 @@ reown() {
   fi
   info "🔑 fixing permissions on $1"
   # change owner and permissions for owner
-  chown "$CURUSR" "$1" && \
-    chmod "u=rwx" "$1"
+  # chmod may fail on NFSv4 (aclmode=restricted) — non-fatal since chown ensures access
+  chown "$CURUSR" "$1"
+  chmod "u=rwx" "$1" 2>/dev/null || true
 }
 # check that directory is writeable
 check_dir_perms() {


### PR DESCRIPTION
## Problem

When running on ZFS with NFSv4 ACLs, the entrypoint encounters two issues that prevent clean startup:

1. **`runas()` never invokes `dropprs` in the standard Docker case.** The condition `$(id -u) -eq 0` is always true when the container starts as root, so the `else` branch containing the `dropprs` call is unreachable. The process runs as root despite PUID/PGID being set.

2. **`dropprs` drops all supplementary groups.** The primary GID is passed to `dropprs` but not included in the supplementary group list. On filesystems that check group membership via supplementary groups (ZFS with NFSv4 ACLs), this causes permission failures even though the GID matches.

3. **`chmod` returns EPERM on ZFS datasets with `aclmode=restricted`.** The `reown()` and `reown_r()` functions chain `chown && chmod`. When ZFS NFSv4 ACL entries are inherited, `chmod()` fails with EPERM, aborting the entrypoint on otherwise valid bind mounts.

## Changes

- Remove the `$(id -u) -eq 0` short-circuit in `runas()` so `dropprs` is actually called for privilege dropping
- Always include `CURGRP` in the supplementary groups passed to `dropprs`, alongside the optional `AVGID`
- Make `chmod` calls in `reown()` / `reown_r()` best-effort (non-fatal), since `chown` already ensures the correct owner has access

## Testing

Tested on TrueNAS Scale with ZFS NFSv4 ACLs (`aclmode=restricted`). Container starts cleanly, stash process runs as the configured PUID/PGID, all bind-mounted directories are accessible, and Python dependencies install without errors.