### PR TITLE
Only collect plugin requirements.txt from directories containing.yml files

### DIFF
--- a/stash/root/opt/entrypoint.sh
+++ b/stash/root/opt/entrypoint.sh
@@ -253,9 +253,14 @@ search_dir_reqs() {
     warn "🐍 $target_dir not found, skipping requirement search"
     return 0
   fi
-  find "$target_dir" -type f -name "requirements.txt" -print0 | while IFS= read -r -d '' file
+  find "$target_dir" -type f -name "*.yml" -print0 | while IFS= read -r -d '' ymlfile
   do
-    parse_reqs "$file"
+    local plugindir
+    plugindir="$(dirname "$ymlfile")"
+    local reqfile="$plugindir/requirements.txt"
+    if [ -f "$reqfile" ]; then
+      parse_reqs "$reqfile"
+    fi
   done
 }
 # parse requirements


### PR DESCRIPTION
The intention of this PR is to limit the search scope for the requirements file.

This solves two problems i am facing:
First is startup time. The find command is fast, but if the plugin has sub-directories in its plugin directory with lots of files, the find command is slowed down. With this PR this is limited to the top level directory of each plugin where the .yml file is located. From what i know this file is mandatory for each plugin, therefore this is a good indicator for the top level folder.

The second problem is incompatiblity with plugins that use their own venv´s (like the LocalVisage plugin). On runtime they create a venv directory in the plugins folder (so the folder where the .yml file is) which then in turn also creates a requirements.txt file, which would also be installed in the main container venv.